### PR TITLE
Fixed 1px border is drawn even when border width is set to 0

### DIFF
--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -93,7 +93,9 @@ public class CircleImageView extends ImageView {
         }
 
         canvas.drawCircle(getWidth() / 2, getHeight() / 2, mDrawableRadius, mBitmapPaint);
-        canvas.drawCircle(getWidth() / 2, getHeight() / 2, mBorderRadius, mBorderPaint);
+        if(mBorderWidth != 0){
+          canvas.drawCircle(getWidth() / 2, getHeight() / 2, mBorderRadius, mBorderPaint);
+        }
     }
 
     @Override


### PR DESCRIPTION
1px border is drawn even when border width is set to ;

Cause:

public void setStrokeWidth (float width)
Added in API level 1
Set the width for stroking. Pass 0 to stroke in hairline mode. Hairlines always draws a single pixel independent of the canva's matrix.
