### PR TITLE
Add support for disabling circular transformation entirely

### DIFF
--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -47,6 +47,7 @@ public class CircleImageView extends ImageView {
 
     private boolean mReady;
     private boolean mSetupPending;
+    private boolean mIsCircularTransformationDisabled;
 
     public CircleImageView(Context context) {
         super(context);
@@ -102,6 +103,11 @@ public class CircleImageView extends ImageView {
 
     @Override
     protected void onDraw(Canvas canvas) {
+        if (mIsCircularTransformationDisabled) {
+            super.onDraw(canvas); // no transformation, i.e. delegate to ImageView
+            return;
+        }
+
         if (getDrawable() == null) {
             return;
         }
@@ -143,6 +149,10 @@ public class CircleImageView extends ImageView {
 
         mBorderWidth = borderWidth;
         setup();
+    }
+
+    public void setIsCircularTransformationDisabled(boolean isCircularTransformationDisabled) {
+        mIsCircularTransformationDisabled = isCircularTransformationDisabled;
     }
 
     @Override


### PR DESCRIPTION
I recently needed a flag to simply turn off the circular transformation entirely and use the `CircleImageView` as a plain old `ImageView`.
Simple addition. Feel free to merge if you find it useful.