### PR TITLE
Added setBorderColorResource() to allow passing color resource references

### DIFF
--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -135,6 +135,10 @@ public class CircleImageView extends ImageView {
         invalidate();
     }
 
+    public void setBorderColorResource(int borderColorRes) {
+        setBorderColor(getContext().getResources().getColor(borderColorRes));
+    }
+
     public int getBorderWidth() {
         return mBorderWidth;
     }


### PR DESCRIPTION
Recently noticed that it's only possible to pass resolved color values to the CircleImageView.

Another thing worth mentioning is that CircleImageView doesn't use the resource annotations (e.g. @ColorRes, @DrawableRes), that are really handy. Will try to handle this in a separate pull request.