### PR TITLE
Add a border_overlay attribute and allow drawing border on image

### DIFF
--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -70,7 +70,7 @@ public class CircleImageView extends ImageView {
 
         mBorderWidth = a.getDimensionPixelSize(R.styleable.CircleImageView_border_width, DEFAULT_BORDER_WIDTH);
         mBorderColor = a.getColor(R.styleable.CircleImageView_border_color, DEFAULT_BORDER_COLOR);
-        mBorderInset = a.getBoolean(R.styleable.CircleImageView_border_inset, DEFAULT_BORDER_INSET );
+        mBorderInset = a.getBoolean(R.styleable.CircleImageView_border_inset, DEFAULT_BORDER_INSET);
 
         a.recycle();
 
@@ -151,18 +151,18 @@ public class CircleImageView extends ImageView {
         setup();
     }
 
-	public boolean getBorderInset() {
-		return mBorderInset;
-	}
+    public boolean getBorderInset() {
+        return mBorderInset;
+    }
 
-	public void setBorderInset(boolean borderInset) {
-		if (borderInset == mBorderInset) {
-			return;
-		}
+    public void setBorderInset(boolean borderInset) {
+        if (borderInset == mBorderInset) {
+            return;
+        }
 
-		mBorderInset = borderInset;
-		setup();
-	}
+        mBorderInset = borderInset;
+        setup();
+    }
 
     @Override
     public void setImageBitmap(Bitmap bm) {
@@ -257,7 +257,9 @@ public class CircleImageView extends ImageView {
         mBorderRadius = Math.min((mBorderRect.height() - mBorderWidth) / 2, (mBorderRect.width() - mBorderWidth) / 2);
 
         mDrawableRect.set(mBorderRect);
-        if (mBorderInset) mDrawableRect.inset(mBorderWidth, mBorderWidth);
+        if (mBorderInset) {
+            mDrawableRect.inset(mBorderWidth, mBorderWidth);
+        }
         mDrawableRadius = Math.min(mDrawableRect.height() / 2, mDrawableRect.width() / 2);
 
         updateShaderMatrix();

--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -27,7 +27,7 @@ public class CircleImageView extends ImageView {
 
     private static final int DEFAULT_BORDER_WIDTH = 0;
     private static final int DEFAULT_BORDER_COLOR = Color.BLACK;
-    private static final boolean DEFAULT_BORDER_INSET = true;
+    private static final boolean DEFAULT_BORDER_OVERLAY = true;
 
     private final RectF mDrawableRect = new RectF();
     private final RectF mBorderRect = new RectF();
@@ -51,7 +51,7 @@ public class CircleImageView extends ImageView {
 
     private boolean mReady;
     private boolean mSetupPending;
-    private boolean mBorderInset;
+    private boolean mBorderOverlay;
 
     public CircleImageView(Context context) {
         super(context);
@@ -70,7 +70,7 @@ public class CircleImageView extends ImageView {
 
         mBorderWidth = a.getDimensionPixelSize(R.styleable.CircleImageView_border_width, DEFAULT_BORDER_WIDTH);
         mBorderColor = a.getColor(R.styleable.CircleImageView_border_color, DEFAULT_BORDER_COLOR);
-        mBorderInset = a.getBoolean(R.styleable.CircleImageView_border_inset, DEFAULT_BORDER_INSET);
+        mBorderOverlay = a.getBoolean(R.styleable.CircleImageView_border_overlay, DEFAULT_BORDER_OVERLAY);
 
         a.recycle();
 
@@ -151,16 +151,16 @@ public class CircleImageView extends ImageView {
         setup();
     }
 
-    public boolean getBorderInset() {
-        return mBorderInset;
+    public boolean isBorderOverlay() {
+        return mBorderOverlay;
     }
 
-    public void setBorderInset(boolean borderInset) {
-        if (borderInset == mBorderInset) {
+    public void setBorderOverlay(boolean borderOverlay) {
+        if (borderOverlay == mBorderOverlay) {
             return;
         }
 
-        mBorderInset = borderInset;
+        mBorderOverlay = borderOverlay;
         setup();
     }
 
@@ -257,7 +257,7 @@ public class CircleImageView extends ImageView {
         mBorderRadius = Math.min((mBorderRect.height() - mBorderWidth) / 2, (mBorderRect.width() - mBorderWidth) / 2);
 
         mDrawableRect.set(mBorderRect);
-        if (mBorderInset) {
+        if (mBorderOverlay) {
             mDrawableRect.inset(mBorderWidth, mBorderWidth);
         }
         mDrawableRadius = Math.min(mDrawableRect.height() / 2, mDrawableRect.width() / 2);

--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -27,7 +27,7 @@ public class CircleImageView extends ImageView {
 
     private static final int DEFAULT_BORDER_WIDTH = 0;
     private static final int DEFAULT_BORDER_COLOR = Color.BLACK;
-    private static final boolean DEFAULT_BORDER_OVERLAY = true;
+    private static final boolean DEFAULT_BORDER_OVERLAY = false;
 
     private final RectF mDrawableRect = new RectF();
     private final RectF mBorderRect = new RectF();
@@ -257,7 +257,7 @@ public class CircleImageView extends ImageView {
         mBorderRadius = Math.min((mBorderRect.height() - mBorderWidth) / 2, (mBorderRect.width() - mBorderWidth) / 2);
 
         mDrawableRect.set(mBorderRect);
-        if (mBorderOverlay) {
+        if (!mBorderOverlay) {
             mDrawableRect.inset(mBorderWidth, mBorderWidth);
         }
         mDrawableRadius = Math.min(mDrawableRect.height() / 2, mDrawableRect.width() / 2);

--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -27,6 +27,7 @@ public class CircleImageView extends ImageView {
 
     private static final int DEFAULT_BORDER_WIDTH = 0;
     private static final int DEFAULT_BORDER_COLOR = Color.BLACK;
+    private static final boolean DEFAULT_BORDER_INSET = true;
 
     private final RectF mDrawableRect = new RectF();
     private final RectF mBorderRect = new RectF();
@@ -50,6 +51,7 @@ public class CircleImageView extends ImageView {
 
     private boolean mReady;
     private boolean mSetupPending;
+    private boolean mBorderInset;
 
     public CircleImageView(Context context) {
         super(context);
@@ -68,6 +70,7 @@ public class CircleImageView extends ImageView {
 
         mBorderWidth = a.getDimensionPixelSize(R.styleable.CircleImageView_border_width, DEFAULT_BORDER_WIDTH);
         mBorderColor = a.getColor(R.styleable.CircleImageView_border_color, DEFAULT_BORDER_COLOR);
+        mBorderInset = a.getBoolean(R.styleable.CircleImageView_border_inset, DEFAULT_BORDER_INSET );
 
         a.recycle();
 
@@ -147,6 +150,19 @@ public class CircleImageView extends ImageView {
         mBorderWidth = borderWidth;
         setup();
     }
+
+	public boolean getBorderInset() {
+		return mBorderInset;
+	}
+
+	public void setBorderInset(boolean borderInset) {
+		if (borderInset == mBorderInset) {
+			return;
+		}
+
+		mBorderInset = borderInset;
+		setup();
+	}
 
     @Override
     public void setImageBitmap(Bitmap bm) {
@@ -240,7 +256,8 @@ public class CircleImageView extends ImageView {
         mBorderRect.set(0, 0, getWidth(), getHeight());
         mBorderRadius = Math.min((mBorderRect.height() - mBorderWidth) / 2, (mBorderRect.width() - mBorderWidth) / 2);
 
-        mDrawableRect.set(mBorderWidth, mBorderWidth, mBorderRect.width() - mBorderWidth, mBorderRect.height() - mBorderWidth);
+        mDrawableRect.set(mBorderRect);
+        if (mBorderInset) mDrawableRect.inset(mBorderWidth, mBorderWidth);
         mDrawableRadius = Math.min(mDrawableRect.height() / 2, mDrawableRect.width() / 2);
 
         updateShaderMatrix();
@@ -263,7 +280,7 @@ public class CircleImageView extends ImageView {
         }
 
         mShaderMatrix.setScale(scale, scale);
-        mShaderMatrix.postTranslate((int) (dx + 0.5f) + mBorderWidth, (int) (dy + 0.5f) + mBorderWidth);
+        mShaderMatrix.postTranslate((int) (dx + 0.5f) + mDrawableRect.left, (int) (dy + 0.5f) + mDrawableRect.top);
 
         mBitmapShader.setLocalMatrix(mShaderMatrix);
     }

--- a/circleimageview/src/main/res/values/attrs.xml
+++ b/circleimageview/src/main/res/values/attrs.xml
@@ -3,6 +3,6 @@
     <declare-styleable name="CircleImageView">
         <attr name="border_width" format="dimension" />
         <attr name="border_color" format="color" />
-        <attr name="border_inset" format="boolean" />
+        <attr name="border_overlay" format="boolean" />
     </declare-styleable>
 </resources>

--- a/circleimageview/src/main/res/values/attrs.xml
+++ b/circleimageview/src/main/res/values/attrs.xml
@@ -3,5 +3,6 @@
     <declare-styleable name="CircleImageView">
         <attr name="border_width" format="dimension" />
         <attr name="border_color" format="color" />
+        <attr name="border_inset" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
Setting the border_inset attribute to `false` tells `CircleImageView` not to scale the image down to fit inside the border. This is useful to draw a translucent outline for subtle background protection without sacrificing any real estate.