### PR TITLE
Added resource annotations to 'resource id' method parameters

### DIFF
--- a/circleimageview/build.gradle
+++ b/circleimageview/build.gradle
@@ -10,4 +10,8 @@ android {
     }
 }
 
+dependencies {
+    provided 'com.android.support:support-annotations:22.1.1'
+}
+
 apply from: 'https://raw.github.com/hdodenhof/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -15,6 +15,8 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
+import android.support.annotation.ColorRes;
+import android.support.annotation.DrawableRes;
 import android.util.AttributeSet;
 import android.widget.ImageView;
 
@@ -135,7 +137,7 @@ public class CircleImageView extends ImageView {
         invalidate();
     }
 
-    public void setBorderColorResource(int borderColorRes) {
+    public void setBorderColorResource(@ColorRes int borderColorRes) {
         setBorderColor(getContext().getResources().getColor(borderColorRes));
     }
 
@@ -167,7 +169,7 @@ public class CircleImageView extends ImageView {
     }
 
     @Override
-    public void setImageResource(int resId) {
+    public void setImageResource(@DrawableRes int resId) {
         super.setImageResource(resId);
         mBitmap = getBitmapFromDrawable(getDrawable());
         setup();


### PR DESCRIPTION
Hi @hdodenhof 

As discussed previously, I've added resource annotations to a couple of methods, that should help avoid problems with passing incorrect resource ids into those methods. This change requires the "support-annotations" library, which is usually bundled in dependencies such as "appcompat-v7", therefore I marked it as "provided".

Best wishes,
Egor