### PR TITLE
Prefix xml custom attributes to avoid conflicts with other libraries

### DIFF
--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -70,9 +70,9 @@ public class CircleImageView extends ImageView {
 
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.CircleImageView, defStyle, 0);
 
-        mBorderWidth = a.getDimensionPixelSize(R.styleable.CircleImageView_border_width, DEFAULT_BORDER_WIDTH);
-        mBorderColor = a.getColor(R.styleable.CircleImageView_border_color, DEFAULT_BORDER_COLOR);
-        mBorderOverlay = a.getBoolean(R.styleable.CircleImageView_border_overlay, DEFAULT_BORDER_OVERLAY);
+        mBorderWidth = a.getDimensionPixelSize(R.styleable.CircleImageView_civ_border_width, DEFAULT_BORDER_WIDTH);
+        mBorderColor = a.getColor(R.styleable.CircleImageView_civ_border_color, DEFAULT_BORDER_COLOR);
+        mBorderOverlay = a.getBoolean(R.styleable.CircleImageView_civ_border_overlay, DEFAULT_BORDER_OVERLAY);
 
         a.recycle();
 

--- a/circleimageview/src/main/res/values/attrs.xml
+++ b/circleimageview/src/main/res/values/attrs.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="CircleImageView">
-        <attr name="border_width" format="dimension" />
-        <attr name="border_color" format="color" />
-        <attr name="border_overlay" format="boolean" />
+        <attr name="civ_border_width" format="dimension" />
+        <attr name="civ_border_color" format="color" />
+        <attr name="civ_border_overlay" format="boolean" />
     </declare-styleable>
 </resources>

--- a/sample/src/main/res/layout/fragment_main.xml
+++ b/sample/src/main/res/layout/fragment_main.xml
@@ -19,8 +19,8 @@
             android:layout_height="160dp"
             android:layout_centerInParent="true"
             android:src="@drawable/hugh"
-            app:border_width="2dp"
-            app:border_color="@color/dark" />
+            app:civ_border_width="2dp"
+            app:civ_border_color="@color/dark" />
 
     </RelativeLayout>
 
@@ -36,8 +36,8 @@
             android:layout_height="160dp"
             android:layout_centerInParent="true"
             android:src="@drawable/hugh"
-            app:border_width="2dp"
-            app:border_color="@color/light" />
+            app:civ_border_width="2dp"
+            app:civ_border_color="@color/light" />
 
     </RelativeLayout>
 


### PR DESCRIPTION
See https://code.google.com/p/android/issues/detail?id=22576

A lot of libraries use `border_width`.