### PR TITLE
Use float numbers in division

### DIFF
--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -114,9 +114,9 @@ public class CircleImageView extends ImageView {
             return;
         }
 
-        canvas.drawCircle(getWidth() / 2, getHeight() / 2, mDrawableRadius, mBitmapPaint);
+        canvas.drawCircle(getWidth() / 2.0f, getHeight() / 2.0f, mDrawableRadius, mBitmapPaint);
         if (mBorderWidth != 0) {
-            canvas.drawCircle(getWidth() / 2, getHeight() / 2, mBorderRadius, mBorderPaint);
+            canvas.drawCircle(getWidth() / 2.0f, getHeight() / 2.0f, mBorderRadius, mBorderPaint);
         }
     }
 
@@ -260,13 +260,13 @@ public class CircleImageView extends ImageView {
         mBitmapWidth = mBitmap.getWidth();
 
         mBorderRect.set(0, 0, getWidth(), getHeight());
-        mBorderRadius = Math.min((mBorderRect.height() - mBorderWidth) / 2, (mBorderRect.width() - mBorderWidth) / 2);
+        mBorderRadius = Math.min((mBorderRect.height() - mBorderWidth) / 2.0f, (mBorderRect.width() - mBorderWidth) / 2.0f);
 
         mDrawableRect.set(mBorderRect);
         if (!mBorderOverlay) {
             mDrawableRect.inset(mBorderWidth, mBorderWidth);
         }
-        mDrawableRadius = Math.min(mDrawableRect.height() / 2, mDrawableRect.width() / 2);
+        mDrawableRadius = Math.min(mDrawableRect.height() / 2.0f, mDrawableRect.width() / 2.0f);
 
         updateShaderMatrix();
         invalidate();


### PR DESCRIPTION
Using CircleImageView with small images has some edge cutting issue on hdpi screens. Changing numbers to float in divisions are solving it.

&lt;de.hdodenhof.circleimageview.CircleImageView
	    xmlns:app="http://schemas.android.com/apk/res-auto" 
        android:id="@+id/ellipse_gray_mini"
        android:src="@drawable/ellipse_gray_mini"
        android:layout_width="31dp"
        android:layout_height="31dp"
        android:layout_margin="7dp"
        android:visibility="visible"
        app:border_width="0dp"
	    app:border_color="#ffffffff" /&gt;
     
Drawable to demonstrate it: 88px * 88px png in res\drawable-xxhdpi.

Before changes:
![before](https://cloud.githubusercontent.com/assets/1240659/7802445/c1628c80-0335-11e5-9f28-c4ab4c276066.png)

After changes:
![after](https://cloud.githubusercontent.com/assets/1240659/7802447/c523e09e-0335-11e5-80a9-907ace083ab3.png)

