### PR TITLE
Setting bitmap to null bugfix

### DIFF
--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -110,7 +110,7 @@ public class CircleImageView extends ImageView {
 
     @Override
     protected void onDraw(Canvas canvas) {
-        if (getDrawable() == null) {
+        if (getDrawable() == null || mBitmap == null) {
             return;
         }
 


### PR DESCRIPTION
If you set the imageview bitmap to null after originally setting it, it will still draw the old bitmap. This commit fixes that