### PR TITLE
Fix  java.lang.IllegalArgumentException: width and height must be > 0…

### DIFF
--- a/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
+++ b/circleimageview/src/main/java/de/hdodenhof/circleimageview/CircleImageView.java
@@ -193,7 +193,6 @@ public class CircleImageView extends ImageView {
      * Return the color drawn behind the circle-shaped drawable.
      *
      * @return The color drawn behind the drawable
-     *
      * @deprecated Fill color support is going to be removed in the future
      */
     @Deprecated
@@ -206,7 +205,6 @@ public class CircleImageView extends ImageView {
      * this has no effect if the drawable is opaque or no drawable is set.
      *
      * @param fillColor The color to be drawn behind the drawable
-     *
      * @deprecated Fill color support is going to be removed in the future
      */
     @Deprecated
@@ -334,7 +332,9 @@ public class CircleImageView extends ImageView {
             if (drawable instanceof ColorDrawable) {
                 bitmap = Bitmap.createBitmap(COLORDRAWABLE_DIMENSION, COLORDRAWABLE_DIMENSION, BITMAP_CONFIG);
             } else {
-                bitmap = Bitmap.createBitmap(drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight(), BITMAP_CONFIG);
+                int width = drawable.getIntrinsicWidth() <= 0 ? COLORDRAWABLE_DIMENSION : drawable.getIntrinsicWidth();
+                int height = drawable.getIntrinsicHeight() <= 0 ? COLORDRAWABLE_DIMENSION : drawable.getIntrinsicHeight();
+                bitmap = Bitmap.createBitmap(width, height, BITMAP_CONFIG);
             }
 
             Canvas canvas = new Canvas(bitmap);


### PR DESCRIPTION
  When use Glide add shapeDrawable as place or error drawable:

     Glide.with(getContext())
                .load(url)
                .dontAnimate()
                .placeholder(R.drawable.shape_empt_night)
                .error(R.drawable.ic_launcher)
                .into(mIv);

or some other ways like:
` mIv.setImageDrawable(getResources().getDrawable(R.drawable.shape_empt_night));`